### PR TITLE
Add workflow to release container images

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,0 +1,46 @@
+name: Push new version
+
+# This workflow runs when any of the following occur:
+# - A push is made to a branch called `main` or `seed`
+# - A tag starting with "v" is created
+# - A pull request is created or updated
+on:
+  push:
+    tags:
+      - v*
+env:
+  IMAGE_NAME: fakes3pp
+
+jobs:
+  # This pushes the image to GitHub Packages.
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        #
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # This changes all uppercase characters to lowercase.
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          # This strips the git ref prefix from the version.
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          # This strips the "v" prefix from the tag name.
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          # This uses the Docker `latest` tag convention.
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+See [releases](https://github.com/VITObelgium/fakes3pp/releases)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
 # Doing a multi-stage build to make sure to have passing of unittests enforced
 FROM docker.io/golang:1.22 AS base
 
-# Credit check tests
+LABEL org.opencontainers.image.source=https://github.com/VITObelgium/fakes3pp
+LABEL org.opencontainers.image.description="FakeS3++ proxies S3 compatible APIs and augment them with extra functionality."
+LABEL org.opencontainers.image.licenses=AGPL-3.0
+
 COPY go.mod /usr/src/fakes3pp/go.mod
 COPY go.sum /usr/src/fakes3pp/go.sum
 WORKDIR /usr/src/fakes3pp

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/VITObelgium/fakes3pp
 
-go 1.22
+go 1.22.3
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.30.5


### PR DESCRIPTION
Allows automatic publishing of a container image when creating a release that is tagged with a version number.

The version number is taken from the tag (e.g. tag `v1.0.0` will result in container image tag `1.0.0`)