### PR TITLE
feature: process nested tag claims

### DIFF
--- a/cmd/handler-builder.go
+++ b/cmd/handler-builder.go
@@ -112,7 +112,8 @@ func authorizeS3Action(ctx context.Context, sessionToken string, action S3ApiAct
 		return
 	}
 
-	policyStr, err := pm.GetPolicy(sessionClaims.RoleARN, PolicyTemplateDataFromClaims(sessionClaims))
+	policySessionData := GetPolicySessionDataFromClaims(sessionClaims)
+	policyStr, err := pm.GetPolicy(sessionClaims.RoleARN, policySessionData)
 	if err != nil {
 		slog.Error("Could not get policy for temporary credentials", "error", err, xRequestIDStr, getRequestID(ctx), "role_arn", sessionClaims.RoleARN)
 		writeS3ErrorResponse(ctx, w, ErrS3InternalError, nil)
@@ -125,7 +126,7 @@ func authorizeS3Action(ctx context.Context, sessionToken string, action S3ApiAct
 		writeS3ErrorResponse(ctx, w, ErrS3InternalError, nil)
 		return
 	}
-	iamActions, err := NewIamActionsFromS3Request(action, r)
+	iamActions, err := newIamActionsFromS3Request(action, r, policySessionData)
 	if err != nil {
 		slog.Error("Could not get IAM actions from request", "error", err, xRequestIDStr, getRequestID(ctx), "policy", sessionClaims.RoleARN)
 		writeS3ErrorResponse(ctx, w, ErrS3InternalError, nil)

--- a/cmd/policy-generation.go
+++ b/cmd/policy-generation.go
@@ -133,20 +133,36 @@ func (m *PolicyManager) getPolicyTemplate(arn string) (tmpl *template.Template, 
 	return 
 }
 
-type policyTemplateData struct {
-	Claims map[string]string
+
+type PolicySessionClaims struct {
+	Subject string
+	Issuer string
 }
 
-func PolicyTemplateDataFromClaims(sc *SessionClaims) policyTemplateData{
-	return policyTemplateData{
-		Claims: map[string]string{
-			"Issuer": sc.IIssuer,
-			"Subject": sc.Subject,
+
+//This is the structure that will be made available during templating and
+//thus is available to be used in policies.
+type PolicySessionData struct {
+	Claims PolicySessionClaims
+	Tags AWSSessionTags
+}
+
+func GetPolicySessionDataFromClaims(claims *SessionClaims) *PolicySessionData {
+	issuer := claims.IIssuer
+	if issuer == "" {
+		issuer = claims.Issuer
+	}
+	return &PolicySessionData{
+		Claims: PolicySessionClaims{
+			Subject: claims.Subject,
+			Issuer: issuer,
 		},
+		Tags: claims.Tags,
 	}
 }
 
-func (m *PolicyManager) GetPolicy(arn string, data policyTemplateData) (string, error) {
+
+func (m *PolicyManager) GetPolicy(arn string, data *PolicySessionData) (string, error) {
 	tmpl, err := m.getPolicyTemplate(arn)
 	if err != nil {
 		return "", err

--- a/cmd/policy-iam-action.go
+++ b/cmd/policy-iam-action.go
@@ -68,6 +68,9 @@ func addGenericSessionContextKeys(context map[string]*policy.ConditionValue, ses
 //Add aws:PrincipalTag/tag-key keys that are added to nearly all requests that contain information about the current session
 //https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-principaltag
 func addAwsPrincipalTagConditionKeys(context map[string]*policy.ConditionValue, session *PolicySessionData) {
+	if session == nil {
+		return
+	}
 	for tagKey, tagValues := range session.Tags.PrincipalTags {
 		context[fmt.Sprintf("aws:PrincipalTag/%s", tagKey)] = policy.NewConditionValueString(true, tagValues...)
 	}

--- a/cmd/proxysts_test.go
+++ b/cmd/proxysts_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	jwt "github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/spf13/viper"
 )
 
@@ -57,6 +59,108 @@ func TestProxySts(t *testing.T) {
 		t.Errorf("Could not assume role with testing token: %v", rr)
 	}
 }
+
+func createBasicRS256PolicyToken(issuer, subject string, expiry time.Duration) (*jwt.Token) {
+	claims := &jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().UTC().Add(expiry)),
+		IssuedAt:  jwt.NewNumericDate(time.Now().UTC()),
+		NotBefore: jwt.NewNumericDate(time.Now().UTC()),
+		Issuer:    issuer,
+		Subject:   subject,
+		ID:        uuid.New().String(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	return token
+}
+
+//Test the most basic web identity token which only has the subject
+func TestProxyStsAssumeRoleWithWebIdentityBasicToken(t *testing.T) {
+	//Given valid server config
+	BindEnvVariables("proxysts")
+	_, err := loadOidcConfig([]byte(testConfigFakeTesting))
+	if err != nil {
+		t.Error(err)
+	}
+	
+	signingKey, err := getTestSigningKey()
+	if err != nil {
+		t.Error("Could not get test signing key")
+		t.FailNow()
+	}
+	token, err := CreateSignedToken(createBasicRS256PolicyToken(testFakeIssuer, testSubject, 20 * time.Minute), signingKey)
+	if err != nil {
+		t.Error("Could create signed token")
+		t.FailNow()
+	}
+
+	//Given the policy Manager that has roleArn for the testARN
+	pm = *NewTestPolicyManagerAllowAll()
+
+
+	url := buildAssumeRoleWithIdentityTokenUrl(901, "mysession", testPolicyAllowAllARN, token)
+	req, err := http.NewRequest("POST", url, nil)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+	rr := httptest.NewRecorder()
+	processSTSPost(rr, req)
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Errorf("Could not assume role with testing token: %v", rr)
+	}
+}
+
+func createRS256PolicyTokenWithSessionTags(issuer, subject string, expiry time.Duration) (*jwt.Token) {
+	tags := AWSSessionTags{
+		PrincipalTags: map[string][]string{
+			"custom_id": {"idA"},
+		},
+		TransitiveTagKeys: []string{"custom_id"},
+	}
+	claims := newIDPClaims(issuer, subject, expiry, tags)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	return token
+}
+
+//Test the most basic web identity token which only has the subject
+func TestProxyStsAssumeRoleWithWebIdentitySessionTagsToken(t *testing.T) {
+	//Given valid server config
+	BindEnvVariables("proxysts")
+	_, err := loadOidcConfig([]byte(testConfigFakeTesting))
+	if err != nil {
+		t.Error(err)
+	}
+	
+	signingKey, err := getTestSigningKey()
+	if err != nil {
+		t.Error("Could not get test signing key")
+		t.FailNow()
+	}
+	token, err := CreateSignedToken(createRS256PolicyTokenWithSessionTags(testFakeIssuer, testSubject, 20 * time.Minute), signingKey)
+	if err != nil {
+		t.Error("Could create signed token")
+		t.FailNow()
+	}
+
+	//Given the policy Manager that has roleArn for the testARN
+	pm = *NewTestPolicyManagerAllowAll()
+
+
+	url := buildAssumeRoleWithIdentityTokenUrl(901, "mysession", testPolicyAllowAllARN, token)
+	req, err := http.NewRequest("POST", url, nil)
+
+    if err != nil {
+        t.Fatal(err)
+    }
+	rr := httptest.NewRecorder()
+	processSTSPost(rr, req)
+	if rr.Result().StatusCode != http.StatusOK {
+		t.Errorf("Could not assume role with testing token: %v", rr)
+	}
+}
+
 
 // This works like a fixture see https://medium.com/nerd-for-tech/setup-and-teardown-unit-test-in-go-bd6fa1b785cd
 func setupSuiteProxySTS(t *testing.T) func(t *testing.T) {


### PR DESCRIPTION
feature: process nested tag claims

Allow IDPs to provide session tags via the nested format.

This is for https://github.com/VITObelgium/fakes3pp/issues/4

As a bonus it also has feature: implement the  Deny effect for policies

Which allowed to create a test case that simulates a scenario where this could be of value.

At this time there are not yet trust policies but since OIDC providers are configured the trust is configured towards OIDC providers. You just cannot distinguish trust on a per role level. For that trust policies are needed which is significantly more work and that could be another future improvement (which will be needed once an sts action like assumeRole gets implemented)