### PR TITLE
ci: allow skipping tests depending on testing backends during build

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -10,6 +10,7 @@ on:
       - v*
 env:
   IMAGE_NAME: fakes3pp
+  NO_TESTING_BACKENDS: "GithubAction" 
 
 jobs:
   # This pushes the image to GitHub Packages.

--- a/cmd/almost-e2e_test.go
+++ b/cmd/almost-e2e_test.go
@@ -53,6 +53,7 @@ func setTestingBackendsConfig(t *testing.T) {
 //This is the testing fixture. It starts an sts and s3 proxy which
 //are configured with the S3 backends detailed in testing/README.md.
 func testingFixture(t *testing.T) (tearDown func ()(), getToken func(subject string, d time.Duration, tags AWSSessionTags) string){
+  skipIfNoTestingBackends(t)
   //Configure backends to be the testing S3 backends
   setTestingBackendsConfig(t)
 	//Given valid server config

--- a/cmd/test-utils.go
+++ b/cmd/test-utils.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"os"
 	"testing"
 )
 
@@ -17,4 +18,12 @@ func printPointerAndJSONStringComparison(t *testing.T, description string, expec
 			t.Errorf("%s: expected %#v, got %#v", description, expected, got)
 		}
 		t.Errorf("%s:\n\t+expected\n\t-got\n\n\t+%s\n\t-%s\n\n\t+%#v\n\t-%#v", description, string(expectedStr), string(gotStr), expected, got)
+}
+
+
+//utility function to not run a test if there are no testing backends in the build environment.
+func skipIfNoTestingBackends(t *testing.T) {
+  if os.Getenv("NO_TESTING_BACKENDS") != "" {
+    t.Skip("Skipping this test because no testing backends and that is a dependency for thist test.")
+  }
 }


### PR DESCRIPTION
When we build a container on github actions we don't have a full testing environment. For our full test suite we need some fake S3 backends running but these are not accessible during the container build.

For the final container build it will be OK to skip these tests as they were run before anyway.