### PR TITLE
bugfix: container build environment variable

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -10,7 +10,6 @@ on:
       - v*
 env:
   IMAGE_NAME: fakes3pp
-  NO_TESTING_BACKENDS: "GithubAction" 
 
 jobs:
   # This pushes the image to GitHub Packages.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /usr/src/fakes3pp
 RUN go mod download
 RUN go mod tidy
 ADD . /usr/src/fakes3pp/
+ENV NO_TESTING_BACKENDS=container_build
 RUN go test -coverprofile cover.out ./...
 RUN go vet
 RUN CGO_ENABLED=0 GOOS=linux go build -o main .


### PR DESCRIPTION
Container builds have their own environment. So setting an environment variable as part of the workflow does not work unless it is passed into the container build.

At this time it makes more sense to have the environment variable just set during container build (but only during the first building stage)