### PR TITLE
security: avoid jinja 3.2.4

### DIFF
--- a/testing/requirements.txt
+++ b/testing/requirements.txt
@@ -18,7 +18,7 @@ Flask-Cors==5.0.0
 graphql-core==3.2.5
 idna==3.10
 itsdangerous==2.2.0
-Jinja2==3.1.4
+Jinja2>=3.1.5, <4
 jmespath==1.0.1
 joserfc==1.0.0
 jsondiff==2.2.1


### PR DESCRIPTION
A bug in the Jinja compiler allows an attacker that controls both the content and filename of a template to execute arbitrary Python code, regardless of if Jinja's sandbox is used.

To exploit the vulnerability, an attacker needs to control both the filename and the contents of a template. Whether that is the case depends on the type of application using Jinja. This vulnerability impacts users of applications which execute untrusted templates where the template author can also choose the template filename.