### PR TITLE
Features/benchmarking and logging

### DIFF
--- a/cmd/api-headers.go
+++ b/cmd/api-headers.go
@@ -31,7 +31,7 @@ func encodeResponse(ctx context.Context, response interface{}) []byte {
 	var buf bytes.Buffer
 	buf.WriteString(xml.Header)
 	if err := xml.NewEncoder(&buf).Encode(response); err != nil {
-		slog.Error("Could not encode xml response", " error", err, xRequestIDStr, getRequestID(ctx))
+		slog.ErrorContext(ctx, "Could not encode xml response", " error", err)
 		return nil
 	}
 	return buf.Bytes()

--- a/cmd/api-response.go
+++ b/cmd/api-response.go
@@ -34,7 +34,7 @@ func writeResponse(ctx context.Context, w http.ResponseWriter, statusCode int, r
 	}
 	// Similar check to http.checkWriteHeaderCode
 	if statusCode < 100 || statusCode > 999 {
-		slog.Error("Internal server error", "error", "invalid WriteHeader code", "statusCode", statusCode, xRequestIDStr, getRequestID(ctx))
+		slog.ErrorContext(ctx, "Internal server error", "error", "invalid WriteHeader code", "statusCode", statusCode)
 		statusCode = http.StatusInternalServerError
 	}
 	if mType != mimeNone {

--- a/cmd/benchmark_test.go
+++ b/cmd/benchmark_test.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+)
+
+
+
+
+func getS3ClientAgainstFakeS3Backend(t testing.TB, region string, creds aws.Credentials) (*s3.Client) {
+	cfg := getTestAwsConfig(t)
+
+	endpoint, ok := fakeTestBackends[region]
+	if !ok {
+		t.Errorf("Got invalid region %s which does not have a fake test backend", region)
+	}
+
+	client := s3.NewFromConfig(cfg, func (o *s3.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+		o.Credentials = adapterCredentialsToCredentialsProvider(creds)
+		o.Region = region
+		o.UsePathStyle = true
+	})
+
+	return client
+}
+
+//This is a helper to be able to read a random string limited to a size while making it seekable.
+//NonDeterministic is an imporant characteristic to be careful with. If you seek the start (offset=0) you can again read N bytes from it but
+//they would not be the same as bytes read previously. 
+//While s3.PutObjectInput takes a Reader it actually requires a ReadSeeker for singing the request (when using HTTPS
+//the s3.PutObjectInput does not sign the payload but when sending over HTTP then it will). So we must reset N of the limited reader when we
+//Seek because the Signing middle ware would consume the reader and the actual request would have an exhausted LimitedReader if we don't action the
+//Seek which would lead in 0-byte objects being sent.
+//You can only use this against dummy backends which do not check Payload signature (like moto which is used in our test cases)
+type nonDeterministicLimitedRandReadSeeker struct{
+	lr io.LimitedReader
+	N  int64  //How much can be maximally read
+}
+
+func newNonDeterministicLimitedRandReadSeeker(n int64) *nonDeterministicLimitedRandReadSeeker{
+	return &nonDeterministicLimitedRandReadSeeker{
+		lr: io.LimitedReader{
+			R: rand.Reader,
+			N: n,
+		},
+		N: n,
+	}
+}
+
+func (ndlrrs *nonDeterministicLimitedRandReadSeeker) Read(b []byte) (n int, err error) {
+	return ndlrrs.lr.Read(b)
+}
+
+func (ndlrrs *nonDeterministicLimitedRandReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	//Reset how much can be read based on the offset seeked
+	if offset > ndlrrs.N {
+		return -1, errors.New("Seek beyond Limit of Limited reader")
+	}
+	ndlrrs.lr.N = ndlrrs.N - offset
+	return offset, nil
+}
+
+
+func createRandomObjectInBackend(c *s3.Client, bucket, key string, size int64) (*s3.PutObjectOutput, error) {
+	rr := newNonDeterministicLimitedRandReadSeeker(size)
+	putObjectInput := s3.PutObjectInput{
+		Bucket: &bucket,
+		Key: &key,
+		Body: rr,
+		ContentLength: &size,
+	}
+	max120Sec, cancel := context.WithTimeout(context.Background(), 120 * time.Second)
+	defer cancel()
+
+	return c.PutObject(
+		max120Sec,
+		&putObjectInput,
+		
+	)
+}
+
+
+
+func getTestBucketObjectContentReadLength(t testing.TB, client s3.Client, objectKey string) (int64, smithy.APIError){	
+	max10Sec, cancel := context.WithTimeout(context.Background(), 10 * time.Second)
+
+	input := s3.GetObjectInput{
+		Bucket: &testingBucketNameBackenddetails,
+		Key: &objectKey,
+	}
+	defer cancel()
+	s3ObjectOutput, err := client.GetObject(max10Sec, &input)
+	if err != nil {
+		var oe smithy.APIError
+		if !errors.As(err, &oe) {
+				t.Errorf("Could not convert smity error")
+				t.FailNow()
+		}
+		return 0, oe
+	}
+	written, err := io.Copy(io.Discard, s3ObjectOutput.Body)
+	if err != nil {
+		t.Errorf("Encountered error %s", err)
+		t.FailNow()
+	}
+	return written, nil
+}
+
+
+func BenchmarkFakeS3Proxy(b *testing.B) {
+	initializeLogging()
+	tearDown, getSignedToken := testingFixture(b)
+	defer tearDown()
+	token := getSignedToken("mySubject", time.Minute * 20, AWSSessionTags{PrincipalTags: map[string][]string{"org": {"a"}}})
+	//Given the policy Manager that has our test policies
+	pm = *NewTestPolicyManagerAlmostE2EPolicies()
+	//Given credentials that use the policy that allow everything in Region1
+	creds := getCredentialsFromTestStsProxy(b, token, "my-session", testPolicyAllowAllInRegion1ARN)
+
+	backendClient := getS3ClientAgainstFakeS3Backend(b, testRegion1, creds)
+	proxyClient := getS3ClientAgainstS3Proxy(b, testRegion1, creds)
+
+	testObject128MBName := "BenchmarkRandomS3Object"
+	testObject128MBSize := int64(128*1024*1024)
+
+	var targets = map[string]*s3.Client{
+		"FakeS3Backend": backendClient,
+		"S3ProxyBeforeFakeS3Backend": proxyClient,
+	}
+
+	testListBucketObjects := func (b *testing.B, testCase string, client *s3.Client) {
+		b.StartTimer()
+		listObjects, err := _listTestBucketObjects(b, "", client)
+		b.StopTimer()
+		//THEN it should just succeed as any action is allowed
+		if err != nil {
+			b.Errorf("Could not get objects in bucket due to error %s", err)
+		} 
+		//THEN it should report the known objects "region.txt" and "team.txt"
+		assertObjectInBucketListing(b, listObjects, "region.txt")
+		assertObjectInBucketListing(b, listObjects, "team.txt")
+	}
+
+	testGetBucketObjectContentReadLength := func (b *testing.B, testCase string, client *s3.Client) {
+		b.StartTimer()
+		bytesRead, err := getTestBucketObjectContentReadLength(b, *backendClient, testObject128MBName)
+		b.StopTimer()
+		//THEN it should just succeed as any action is allowed
+		if err != nil {
+			b.Errorf("Could not get objects in bucket due to error %s", err)
+		} 
+		if bytesRead != testObject128MBSize {
+			b.Errorf("Read %d bytes but uploaded %d bytes", bytesRead, testObject128MBSize)
+		}
+	}
+
+
+	createRandomObject128MB := func(b *testing.B, testCase string, client *s3.Client) {
+		b.StartTimer()
+		_, err := createRandomObjectInBackend(client, testingBucketNameBackenddetails, testObject128MBName, testObject128MBSize)
+		b.StopTimer()
+		//THEN it should just succeed as any action is allowed
+		if err != nil {
+			b.Errorf("Could not create object in bucket due to error %s", err)
+		} 
+	}
+
+	var testCases = []struct{
+		Name string
+		Func func (*testing.B, string, *s3.Client)
+	} {
+		{"createRandomObject256MB", createRandomObject128MB},
+		{"listBucketObjects", testListBucketObjects},
+		{"getBucketObjectContentReadLength", testGetBucketObjectContentReadLength},
+	}
+
+	b.ResetTimer()
+	b.StopTimer()
+	for targetName, targetClient := range targets {
+		for _, testCase := range testCases {
+			testName := fmt.Sprintf("%s-%s", targetName, testCase.Name)
+			b.Run(testName, func(b *testing.B) {
+				for i := 0; i < b.N; i++ {
+					testCase.Func(b, testName, targetClient)
+				}
+			})
+		}
+	}
+}

--- a/cmd/benchmark_test.go
+++ b/cmd/benchmark_test.go
@@ -119,7 +119,7 @@ func getTestBucketObjectContentReadLength(t testing.TB, client s3.Client, object
 
 
 func BenchmarkFakeS3Proxy(b *testing.B) {
-	initializeLogging()
+	initializeTestLogging()
 	tearDown, getSignedToken := testingFixture(b)
 	defer tearDown()
 	token := getSignedToken("mySubject", time.Minute * 20, AWSSessionTags{PrincipalTags: map[string][]string{"org": {"a"}}})

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -52,6 +52,7 @@ const(
 	stsMaxDurationSeconds = "stsMaxDurationSeconds"
 	signedUrlGraceTimeSeconds = "signedUrlGraceTimeSeconds"
 	enableLegacyBehaviorInvalidRegionToDefaultRegion = "enableLegacyBehaviorInvalidRegionToDefaultRegion"
+	logLevel = "logLevel"
 	
 
 	//Environment variables are upper cased
@@ -73,6 +74,7 @@ const(
 	FAKES3PP_STS_MAX_DURATION_SECONDS = "FAKES3PP_STS_MAX_DURATION_SECONDS"
 	FAKES3PP_SIGNEDURL_GRACE_TIME_SECONDS = "FAKES3PP_SIGNEDURL_GRACE_TIME_SECONDS"
 	ENABLE_LEGACY_BEHAVIOR_INVALID_REGION_TO_DEFAULT_REGION = "ENABLE_LEGACY_BEHAVIOR_INVALID_REGION_TO_DEFAULT_REGION"
+	LOG_LEVEL = "LOG_LEVEL"
 )
 
 var envVarDefs = []envVarDef{
@@ -197,6 +199,13 @@ var envVarDefs = []envVarDef{
 		"If set to true invalid regions will not necessarily fail but will try default region",
 		[]string{proxys3},
 	},
+	{
+		logLevel,
+		LOG_LEVEL,
+		false,
+		"The Loglevel at which to run (DEBUG, INFO (default), WARN, ERROR)",
+		[]string{proxys3, proxysts},
+	},
 }
 
 func getSignedUrlGraceTimeSeconds() time.Duration {
@@ -294,10 +303,12 @@ func BindEnvVariables(cmd string) {
 func checkViperVarNotEmpty(evd envVarDef) {
 	r := viper.Get(evd.viperKey)
 	if r == nil {
-		fmt.Printf("key %s[%s](%s) is emtpy\n", evd.viperKey, evd.envVarName, evd.description)
 		if evd.isCritical {
+			slog.Error("Mandatory key is empty", "viperKey", evd.viperKey, "envVarName", evd.envVarName, "description", evd.description)
 			fmt.Printf("key %s[%s] is mandatory, aborting\n", evd.viperKey, evd.envVarName)
 			os.Exit(1)
+		} else {
+			slog.Info("Optional key empty", "viperKey", evd.viperKey, "envVarName", evd.envVarName, "description", evd.description)
 		}
 	}
 }

--- a/cmd/handler-builder.go
+++ b/cmd/handler-builder.go
@@ -269,7 +269,13 @@ func (hb handlerBuilder) Build(action S3ApiAction, presigned bool) (http.Handler
 				//Cleaning could have removed content length
 				r.ContentLength = backupContentLength
 
-	            targetRegion := requestutils.GetRegionFromRequest(r, globalBackendsConfig.defaultBackend)
+				var defaultBackend = ""
+				if globalBackendsConfig != nil {
+					defaultBackend = globalBackendsConfig.defaultBackend
+				} else {
+					slog.ErrorContext(ctx, "globalBackendsConfig is expected to be always initialized")
+				}
+	            targetRegion := requestutils.GetRegionFromRequest(r, defaultBackend)
 
 				//Authn done time to perform authorization				
 				if authorizeS3Action(ctx, creds.SessionToken, targetRegion, action, w, r, time.Now().UTC()){

--- a/cmd/handler-builder.go
+++ b/cmd/handler-builder.go
@@ -265,7 +265,7 @@ func (hb handlerBuilder) Build(action S3ApiAction, presigned bool) (http.Handler
 			calculatedSignature := clonedReq.Header.Get(constants.AuthorizationHeader) 
 			passedSignature := r.Header.Get(constants.AuthorizationHeader)
 			if calculatedSignature == passedSignature {
-				slog.Info("Valid signature", xRequestIDStr, getRequestID(ctx))
+				slog.Debug("Valid signature", xRequestIDStr, getRequestID(ctx))
 				//Cleaning could have removed content length
 				r.ContentLength = backupContentLength
 
@@ -400,7 +400,7 @@ func reTargetRequest(r *http.Request, backendId string) (error) {
 	r.Header.Add("Host", endpoint.getHost())
 	r.Host = endpoint.getHost()
 	origRawQuery := r.URL.RawQuery
-	slog.Info("Stored orig RawQuery", "raw_query", origRawQuery)
+	slog.Debug("Stored orig RawQuery", "raw_query", origRawQuery)
 
 	u, err := url.Parse(fmt.Sprintf("%s%s", endpoint.getBaseURI(), r.RequestURI))
     if err != nil {
@@ -411,6 +411,6 @@ func reTargetRequest(r *http.Request, backendId string) (error) {
     r.URL = u
 
 	r.URL.RawQuery = origRawQuery
-	slog.Info("RawQuery that is put in place", "raw_query", r.URL.RawQuery)
+	slog.Debug("RawQuery that is put in place", "raw_query", r.URL.RawQuery)
 	return nil
 }

--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -5,8 +5,23 @@ import (
 	"os"
 )
 
+func getLogLevel() (lvl slog.Level) {
+	logLevelOS, ok := os.LookupEnv("LOG_LEVEL")
+	if !ok {
+		return lvl
+	}
+	err := lvl.UnmarshalText([]byte(logLevelOS))
+	if err != nil {
+		slog.Warn("Invalid log level", "environ_value", logLevelOS)
+	}
+	return 
+
+}
 
 func initializeLogging() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	options := slog.HandlerOptions{
+		Level: getLogLevel(),
+	}
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &options))
 	slog.SetDefault(logger)
 }

--- a/cmd/loghelpers_test.go
+++ b/cmd/loghelpers_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/VITObelgium/fakes3pp/logging"
+)
+
+//For testing only get lines out of a buffer
+func logBufferToLines(tb testing.TB, buf *bytes.Buffer) []string {
+	var lines = []string{}
+	lineDelimiter := byte('\n')
+	for i:=0 ; i < 10000; i++ {
+		line, err := buf.ReadString(lineDelimiter)
+		if err == nil {
+			lines = append(lines, line)
+		} else {
+			if err == io.EOF {
+				return lines
+			}
+			tb.Errorf("Encountered error while processing log buffer: %s", err)
+			tb.FailNow()
+		}
+	}
+	return lines
+}
+
+//A fixture to start capturing logs. It returns the following:
+// - a teardown callback to stop the log capture.
+// - a getCapturedLogLines callback which gets the log lines captured since the last run
+func captureLogFixture(tb testing.TB, lvl slog.Level, fe logging.ForceEnabler) (teardown func()(), getCapturedLogLines func()([]string)) {
+	loggerBeforeFixture := slog.Default()
+	buf := &bytes.Buffer{}
+	logging.InitializeLogging(lvl, fe, buf)
+	var fixtureActive = true
+
+	teardown = func() {
+		if fixtureActive {
+			slog.SetDefault(loggerBeforeFixture)
+			fixtureActive = false
+		}
+	}
+
+	getCapturedLogLines = func() (lines []string) {
+		lines = logBufferToLines(tb, buf)
+		return lines
+	}
+
+	return teardown, getCapturedLogLines
+}

--- a/cmd/policy-api-action_test.go
+++ b/cmd/policy-api-action_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/http"
 	"testing"
+
+	"github.com/VITObelgium/fakes3pp/requestctx"
 )
 
 
@@ -20,7 +22,7 @@ func (p *StubJustReturnApiAction) Build(action S3ApiAction, presigned bool) http
 		//of the api action
 		globalLastApiActionStubJustReturnApiAction = action
 		writeS3ErrorResponse(
-			buildContextWithRequestID(r),
+			requestctx.NewContextFromHttpRequest(r),
 			w,
 			ErrS3AccessDenied,
 			errors.New(string(action)),

--- a/cmd/policy-iam-action_test.go
+++ b/cmd/policy-iam-action_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/VITObelgium/fakes3pp/requestctx"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/micahhausler/aws-iam-policy/policy"
@@ -40,7 +41,7 @@ func (p *StubJustReturnIamAction) Build(action S3ApiAction, presigned bool) http
 		//of the api action. This works often quite well but some operations 
 		//intervene client-side of the SDK
 		writeS3ErrorResponse(
-			buildContextWithRequestID(r),
+			requestctx.NewContextFromHttpRequest(r),
 			w,
 			ErrS3AccessDenied,
 			errors.New(string(bytes)),

--- a/cmd/policy-retrieval.go
+++ b/cmd/policy-retrieval.go
@@ -25,8 +25,14 @@ type LocalPolicyRetriever struct{
 	watcher *fsnotify.Watcher
 }
 
+var localPolicyRetrievers map[string]*LocalPolicyRetriever = map[string]*LocalPolicyRetriever{}
+
 func NewLocalPolicyRetriever(stsRolePolicyPath string) *LocalPolicyRetriever {
-	var lp *LocalPolicyRetriever
+	lp, ok := localPolicyRetrievers[stsRolePolicyPath]
+	if ok {
+		slog.Warn("Getting lp from cache", "stsRolePolicyPath", stsRolePolicyPath)
+		return lp
+	}
 
 	var fileDeleted fileCallback = func(fileName string) {
 		if lp.pm == nil {
@@ -63,6 +69,8 @@ func NewLocalPolicyRetriever(stsRolePolicyPath string) *LocalPolicyRetriever {
 		rolePolicyPath: stsRolePolicyPath,
 		watcher: watcher,
 	}
+
+	localPolicyRetrievers[stsRolePolicyPath] = lp
 
 	return lp
 }

--- a/cmd/proxys3.go
+++ b/cmd/proxys3.go
@@ -53,7 +53,7 @@ func createAndStartS3Proxy(proxyHB handlerBuilderI) (*sync.WaitGroup, *http.Serv
 
 	registerS3Router(router, proxyHB)
 	listenAddress := fmt.Sprintf(":%d", portNr)
-	slog.Info("Started listening", "port", portNr)
+	slog.Debug("Started listening", "port", portNr)
 
 	srv := &http.Server{Addr: listenAddress}
 	srv.Handler = router
@@ -63,10 +63,10 @@ func createAndStartS3Proxy(proxyHB handlerBuilderI) (*sync.WaitGroup, *http.Serv
 		defer s3ProxyDone.Done()
 		var err error
 		if secure {
-			slog.Info("Starting ListenAndServeTLS", "secure", secure)
+			slog.Debug("Starting ListenAndServeTLS", "secure", secure)
 			err = srv.ListenAndServeTLS(certFile, keyFile)
 		} else {
-			slog.Info("Starting ListenAndServe", "secure", secure)
+			slog.Debug("Starting ListenAndServe", "secure", secure)
 			err = srv.ListenAndServe()
 		}
 

--- a/cmd/proxys3_test.go
+++ b/cmd/proxys3_test.go
@@ -150,7 +150,7 @@ func popLastRequestByTestProxy() (*http.Request) {
 var testStubJustProxy handlerBuilderI = handlerBuilder{proxyFunc: testProxyStub}
 
 
-func setupSuiteProxyS3(t *testing.T, handlerBuilder handlerBuilderI) (func(t *testing.T)) {
+func setupSuiteProxyS3(t testing.TB, handlerBuilder handlerBuilderI) (func(t testing.TB)) {
 	// Have test Config
 	BindEnvVariables(proxys3)
 	// Make sure proxy key config is there 
@@ -167,7 +167,7 @@ func setupSuiteProxyS3(t *testing.T, handlerBuilder handlerBuilderI) (func(t *te
 	}
 
 	// Return a function to teardown the test
-	return func(t *testing.T) {
+	return func(t testing.TB) {
 		if err := s3ProxySrv.Shutdown(context.Background()); err != nil {
 			panic(err)
 		}
@@ -205,7 +205,7 @@ func adapterAwsCredentialsToCredentials(creds AWSCredentials) aws.Credentials {
 }
 
 
-func getS3ClientAgainstS3Proxy(t *testing.T, region string, creds aws.Credentials) (*s3.Client) {
+func getS3ClientAgainstS3Proxy(t testing.TB, region string, creds aws.Credentials) (*s3.Client) {
 	cfg := getTestAwsConfig(t)
 
 	client := s3.NewFromConfig(cfg, func (o *s3.Options) {

--- a/cmd/proxys3_test.go
+++ b/cmd/proxys3_test.go
@@ -20,7 +20,7 @@ func TestMain(m *testing.M) {
 	envFiles = "../etc/.env"
 	loadEnvVarsFromDotEnv()
 	initConfig()
-	initializeLogging()
+	initializeTestLogging()
 	m.Run()
 }
 
@@ -428,7 +428,6 @@ func TestWithValidCredsButProxyHeaders(t *testing.T) {
 	}
 	req.Header.Add("User-Agent", "aws-cli/2.15.40 Python/3.11.8 Linux/6.8.0-40-generic exe/x86_64.ubuntu.12 prompt/off command/s3.ls")
 	req.Header.Add("X-Amz-Content-SHA256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-	ctx = buildContextWithRequestID(req)
 	err = presign.SignWithCreds(ctx, req, awsCred, testDefaultBackendRegion)
 	if err != nil {
 		t.Error(err)
@@ -483,7 +482,6 @@ func TestWithValidCredsButUntrustedHeaders(t *testing.T) {
 	}
 	req.Header.Add("User-Agent", "aws-cli/2.15.40 Python/3.11.8 Linux/6.8.0-40-generic exe/x86_64.ubuntu.12 prompt/off command/s3.ls")
 	req.Header.Add("X-Amz-Content-SHA256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
-	ctx = buildContextWithRequestID(req)
 	err = presign.SignWithCreds(ctx, req, awsCred, testDefaultBackendRegion)
 	if err != nil {
 		t.Error(err)

--- a/cmd/proxysts_test.go
+++ b/cmd/proxysts_test.go
@@ -26,7 +26,7 @@ func buildAssumeRoleWithIdentityTokenUrl(duration int, roleSessionName, roleArn,
 	)
 }
 
-func getTestingToken(t *testing.T) string{
+func getTestingToken(t testing.TB) string{
 	token, err := CreateSignedTestingToken()
 	if err != nil {
 		t.Errorf("Could not create a testing token %s", err)
@@ -164,8 +164,8 @@ func TestProxyStsAssumeRoleWithWebIdentitySessionTagsToken(t *testing.T) {
 
 
 // This works like a fixture see https://medium.com/nerd-for-tech/setup-and-teardown-unit-test-in-go-bd6fa1b785cd
-func setupSuiteProxySTS(t *testing.T) func(t *testing.T) {
-	// Make sure OIDC config is for testing 
+func setupSuiteProxySTS(t testing.TB) func(t testing.TB) {
+	// Make sure OIDC config is for testing
 	_, err := loadOidcConfig([]byte(testConfigAll))
 	if err != nil {
 		t.Errorf("Failed to load OIDC config due to %s", err)
@@ -179,7 +179,7 @@ func setupSuiteProxySTS(t *testing.T) func(t *testing.T) {
 	}
 
 	// Return a function to teardown the test
-	return func(t *testing.T) {
+	return func(t testing.TB) {
 		if err := stsProxySrv.Shutdown(context.Background()); err != nil {
 			panic(err)
 		}
@@ -191,7 +191,7 @@ func setupSuiteProxySTS(t *testing.T) func(t *testing.T) {
 //Just get basic config but disable TLS verification
 //As for tests we use self-signed requests and all is
 //on localhost anyway
-func getTestAwsConfig(t *testing.T) (aws.Config) {
+func getTestAwsConfig(t testing.TB) (aws.Config) {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		t.Error(err)
@@ -213,7 +213,7 @@ func getStsProxyUrl() string {
 	return fmt.Sprintf("%s:%d/", getStsProxyUrlWithoutPort(), viper.GetInt(stsProxyPort))
 }
 
-func assumeRoleWithWebIdentityAgainstTestStsProxy(t *testing.T, token, roleSessionName, roleArn string) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+func assumeRoleWithWebIdentityAgainstTestStsProxy(t testing.TB, token, roleSessionName, roleArn string) (*sts.AssumeRoleWithWebIdentityOutput, error) {
 	cfg := getTestAwsConfig(t)
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/VITObelgium/fakes3pp/logging"
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -39,7 +40,7 @@ func Execute() {
 }
 
 func init() {
-	initializeLogging()
+	logging.InitializeLogging(nil, logging.EnvironmentLvl)
 	rootCmd.PersistentFlags().StringVar(&envFiles, "dot-env", "etc/.env", "File paths to .env files comma separated")
 
 	cobra.OnInitialize(initConfig)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,7 @@ func Execute() {
 }
 
 func init() {
-	logging.InitializeLogging(nil, logging.EnvironmentLvl)
+	logging.InitializeLogging(logging.EnvironmentLvl, nil, nil)
 	rootCmd.PersistentFlags().StringVar(&envFiles, "dot-env", "etc/.env", "File paths to .env files comma separated")
 
 	cobra.OnInitialize(initConfig)

--- a/cmd/s3-errors.go
+++ b/cmd/s3-errors.go
@@ -27,6 +27,8 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+
+	"github.com/VITObelgium/fakes3pp/requestctx"
 )
 
 // writeS3ErrorResponse writes error headers
@@ -36,7 +38,7 @@ func writeS3ErrorResponse(ctx context.Context, w http.ResponseWriter, errCode S3
 	// Generate error response.
 	s3ErrorResponse := S3ErrorResponse{}
 	s3ErrorResponse.Code = s3Err.Code
-	s3ErrorResponse.RequestID = getRequestID(ctx)
+	s3ErrorResponse.RequestID = requestctx.GetRequestID(ctx)
 	s3ErrorResponse.Message = s3Err.Description
 	if err != nil {
 		//Golang doesn't like capitalized error strings but AWS errors seem to prefer it
@@ -44,7 +46,7 @@ func writeS3ErrorResponse(ctx context.Context, w http.ResponseWriter, errCode S3
 	}
 	switch errCode {
 	case ErrS3InternalError, ErrS3UpstreamError:
-		slog.Error("S3 error", "error", err, xRequestIDStr, s3ErrorResponse.RequestID)
+		slog.ErrorContext(ctx, "S3 error", "error", err)
 	}
 	encodedErrorResponse := encodeResponse(ctx, s3ErrorResponse)
 	writeResponse(ctx, w, s3Err.HTTPStatusCode, encodedErrorResponse, mimeXML)

--- a/cmd/sts-errors.go
+++ b/cmd/sts-errors.go
@@ -24,6 +24,8 @@ import (
 	"encoding/xml"
 	"log/slog"
 	"net/http"
+
+	"github.com/VITObelgium/fakes3pp/requestctx"
 )
 
 // writeSTSErrorResponse writes error headers
@@ -33,14 +35,14 @@ func writeSTSErrorResponse(ctx context.Context, w http.ResponseWriter, errCode S
 	// Generate error response.
 	stsErrorResponse := STSErrorResponse{}
 	stsErrorResponse.Error.Code = stsErr.Code
-	stsErrorResponse.RequestID = getRequestID(ctx)
+	stsErrorResponse.RequestID = requestctx.GetRequestID(ctx)
 	stsErrorResponse.Error.Message = stsErr.Description
 	if err != nil {
 		stsErrorResponse.Error.Message = err.Error()
 	}
 	switch errCode {
 	case ErrSTSInternalError, ErrSTSUpstreamError:
-		slog.Error("STS error", "error", err, xRequestIDStr, stsErrorResponse.RequestID)
+		slog.ErrorContext(ctx, "STS error", "error", err)
 	}
 	encodedErrorResponse := encodeResponse(ctx, stsErrorResponse)
 	writeResponse(ctx, w, stsErr.HTTPStatusCode, encodedErrorResponse, mimeXML)

--- a/cmd/test-utils.go
+++ b/cmd/test-utils.go
@@ -2,12 +2,18 @@ package cmd
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/VITObelgium/fakes3pp/logging"
 )
 
+func initializeTestLogging() {
+	logging.InitializeLogging(nil, slog.LevelError)
+}
 
 func printPointerAndJSONStringComparison(t *testing.T, description string, expected, got any) {
 		//Different amount of actions returned so should be rather obvious

--- a/cmd/test-utils.go
+++ b/cmd/test-utils.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"log/slog"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -78,4 +79,10 @@ func isTrueWithinDueTime(callable predicateFunction, waitTimes ...time.Duration)
 		time.Sleep(waitTimeBetweenChecks)
 	}
 
+}
+
+func assertHttpRequestOK(tb testing.TB, resp *http.Response) {
+	if resp.StatusCode != http.StatusOK {
+		tb.Errorf("Should have gotten succesful request")
+	}
 }

--- a/cmd/test-utils.go
+++ b/cmd/test-utils.go
@@ -12,7 +12,7 @@ import (
 )
 
 func initializeTestLogging() {
-	logging.InitializeLogging(nil, slog.LevelError)
+	logging.InitializeLogging(slog.LevelError, nil, nil)
 }
 
 func printPointerAndJSONStringComparison(t *testing.T, description string, expected, got any) {

--- a/cmd/test-utils.go
+++ b/cmd/test-utils.go
@@ -24,7 +24,7 @@ func printPointerAndJSONStringComparison(t *testing.T, description string, expec
 
 
 //utility function to not run a test if there are no testing backends in the build environment.
-func skipIfNoTestingBackends(t *testing.T) {
+func skipIfNoTestingBackends(t testing.TB) {
   if os.Getenv("NO_TESTING_BACKENDS") != "" {
     t.Skip("Skipping this test because no testing backends and that is a dependency for thist test.")
   }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -72,6 +72,6 @@ func capitalizeFirstLetter(s string) string {
 func WriteButLogOnError(ctx context.Context, w http.ResponseWriter, bytes []byte) {
 	_, err := w.Write(bytes)
 	if err != nil {
-		slog.Warn("Could not write HTTP response body", "error", err, xRequestIDStr, getRequestID(ctx))
+		slog.WarnContext(ctx, "Could not write HTTP response body", "error", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.62.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.30.8
 	github.com/aws/smithy-go v1.20.4
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-http-utils/headers v0.0.0-20181008091004-fed159eddc2a
 	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
@@ -33,7 +34,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.17.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.22.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.26.8 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect

--- a/logging/enabler.go
+++ b/logging/enabler.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 	"log/slog"
+	"os"
 	"strings"
 
 	"github.com/VITObelgium/fakes3pp/requestctx"
@@ -36,5 +37,22 @@ func (f forceForRequestIdPrefix) IsForceEnabled(ctx context.Context, _ slog.Leve
 func NewForceForRequestIdPrefix(Prefix string) *forceForRequestIdPrefix{
 	return &forceForRequestIdPrefix{
 		Prefix: Prefix,
+	}
+}
+
+
+const ENV_FORCE_LOGGING_FOR_REQUEST_ID_PREFIX = "FORCE_LOGGING_FOR_REQUEST_ID_PREFIX"
+
+//The exection environment decides when to force logging. If it an environment variable
+//FORCE_LOGGING_FOR_REQUEST_ID_PREFIX is set then logging will be forced for requests that
+//have a request ID that start with that value.
+func getDefaultForceEnableLoggingStrategy() ForceEnabler {
+	prefix := os.Getenv(ENV_FORCE_LOGGING_FOR_REQUEST_ID_PREFIX)
+	if prefix != "" {
+		slog.Debug("Enable force logging for prefix", "prefix", prefix)
+		return NewForceForRequestIdPrefix(prefix)
+	} else {
+		slog.Debug("Never force logging.")
+		return &neverForce{}
 	}
 }

--- a/logging/enabler.go
+++ b/logging/enabler.go
@@ -1,0 +1,40 @@
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	"github.com/VITObelgium/fakes3pp/requestctx"
+)
+
+
+type ForceEnabler interface {
+	IsForceEnabled(context.Context, slog.Level) bool
+}
+
+//By default we do not force logging to be enabled.
+type neverForce struct {}
+
+func (f neverForce) IsForceEnabled(_ context.Context, _ slog.Level) bool {
+	return false
+}
+
+
+type forceForRequestIdPrefix struct {
+	Prefix string
+}
+
+func (f forceForRequestIdPrefix) IsForceEnabled(ctx context.Context, _ slog.Level) bool {
+	reqCtx, ok := requestctx.FromContext(ctx)
+	if ok {
+		return strings.HasPrefix(reqCtx.RequestID, f.Prefix)
+	}
+	return false
+}
+
+func NewForceForRequestIdPrefix(Prefix string) *forceForRequestIdPrefix{
+	return &forceForRequestIdPrefix{
+		Prefix: Prefix,
+	}
+}

--- a/logging/general.go
+++ b/logging/general.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"io"
 	"log/slog"
 	"os"
 )
@@ -20,13 +21,22 @@ func getLogLevel() (lvl slog.Level) {
 var EnvironmentLvl slog.Level = -2147483648
 
 
-func InitializeLogging(forceEnabler ForceEnabler, lvl slog.Level) {
+//Configure logging
+//forceEnabler and sink can be nil and they will get sane defaults based on the environment.
+func InitializeLogging(lvl slog.Level, forceEnabler ForceEnabler,  sink io.Writer) {
 	if lvl == EnvironmentLvl {
 		lvl = getLogLevel()
 	}
 	options := slog.HandlerOptions{
 		Level: lvl,
 	}
-	logger := slog.New(NewJSONRequestCtxHandler(os.Stdout, &options, forceEnabler))
+	if sink == nil {
+		sink = os.Stdout
+	}
+	logger := slog.New(NewJSONRequestCtxHandler(sink, &options, forceEnabler))
 	slog.SetDefault(logger)
+	if lvl == EnvironmentLvl {
+		//Still the place holder value probably misconfiguration of environment
+		slog.Warn("LOG_LEVEL environment variable not set! Using sentinel logLvl", "logLvl", lvl)
+	}
 }

--- a/logging/general.go
+++ b/logging/general.go
@@ -1,4 +1,4 @@
-package cmd
+package logging
 
 import (
 	"log/slog"
@@ -15,13 +15,18 @@ func getLogLevel() (lvl slog.Level) {
 		slog.Warn("Invalid log level", "environ_value", logLevelOS)
 	}
 	return 
-
 }
 
-func initializeLogging() {
-	options := slog.HandlerOptions{
-		Level: getLogLevel(),
+var EnvironmentLvl slog.Level = -2147483648
+
+
+func InitializeLogging(forceEnabler ForceEnabler, lvl slog.Level) {
+	if lvl == EnvironmentLvl {
+		lvl = getLogLevel()
 	}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &options))
+	options := slog.HandlerOptions{
+		Level: lvl,
+	}
+	logger := slog.New(NewJSONRequestCtxHandler(os.Stdout, &options, forceEnabler))
 	slog.SetDefault(logger)
 }

--- a/logging/handler.go
+++ b/logging/handler.go
@@ -20,7 +20,7 @@ type JSONRequestCtxHandler struct {
 func NewJSONRequestCtxHandler(w io.Writer, opts *slog.HandlerOptions, forceEnabler ForceEnabler) *JSONRequestCtxHandler {
 	h := slog.NewJSONHandler(w, opts)
 	if forceEnabler == nil {
-		forceEnabler = &neverForce{}
+		forceEnabler = getDefaultForceEnableLoggingStrategy()
 	}
 	return &JSONRequestCtxHandler{h, forceEnabler}
 }

--- a/logging/handler.go
+++ b/logging/handler.go
@@ -1,0 +1,55 @@
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+
+	"github.com/VITObelgium/fakes3pp/requestctx"
+)
+
+// JSONRequestCtxHandler is a [Handler] that writes Records to an [io.Writer] as
+// line-delimited JSON objects while checking RequestContext.
+type JSONRequestCtxHandler struct {
+	wrappedHandler slog.Handler
+
+	//A hook to make sure records are logged if they are of a certain level or a specific context was passed 
+	forceEnabler ForceEnabler
+}
+
+func NewJSONRequestCtxHandler(w io.Writer, opts *slog.HandlerOptions, forceEnabler ForceEnabler) *JSONRequestCtxHandler {
+	h := slog.NewJSONHandler(w, opts)
+	if forceEnabler == nil {
+		forceEnabler = &neverForce{}
+	}
+	return &JSONRequestCtxHandler{h, forceEnabler}
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// The handler ignores records whose level is lower.
+func (h *JSONRequestCtxHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	if h.forceEnabler.IsForceEnabled(ctx, level) {
+		return true
+	}
+	return h.wrappedHandler.Enabled(ctx, level)
+}
+
+// WithAttrs returns a new [JSONHandler] whose attributes consists
+// of h's attributes followed by attrs.
+func (h *JSONRequestCtxHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+
+	return &JSONRequestCtxHandler{wrappedHandler: h.wrappedHandler.WithAttrs(attrs), forceEnabler: h.forceEnabler}
+}
+
+func (h *JSONRequestCtxHandler) WithGroup(name string) slog.Handler {
+	return &JSONRequestCtxHandler{wrappedHandler: h.wrappedHandler.WithGroup(name), forceEnabler: h.forceEnabler}
+}
+
+func (h *JSONRequestCtxHandler) Handle(ctx context.Context, r slog.Record) error {
+	rCtx, ok := requestctx.FromContext(ctx)
+	if ok && rCtx.RequestID != "" {
+		r.AddAttrs(slog.String("RequestId", rCtx.RequestID))
+	}
+	
+	return h.wrappedHandler.Handle(ctx, r)
+}

--- a/presign/header-operations.go
+++ b/presign/header-operations.go
@@ -73,6 +73,6 @@ func CleanHeadersTo(ctx context.Context, req *http.Request, toKeep map[string]st
 		}
 	}
 	if riskySkips > 0 {
-		slog.Warn("Cleaning of headers done but some where skipped.", "cleaned", cleaned, "skipped", skipped, "toKeep", signed)
+		slog.WarnContext(ctx, "Cleaning of headers done but some where skipped.", "cleaned", cleaned, "skipped", skipped, "toKeep", signed)
 	}
 }

--- a/presign/s3v4.go
+++ b/presign/s3v4.go
@@ -83,7 +83,7 @@ func SignWithCreds(ctx context.Context, req *http.Request, creds aws.Credentials
 		var err error
 		signingTime, err = XAmzDateToTime(amzDate)
 		if err != nil {
-			slog.Warn("Could not handle X-amz-date", constants.AmzDateKey, amzDate, "error", err)
+			slog.WarnContext(ctx, "Could not handle X-amz-date", constants.AmzDateKey, amzDate, "error", err)
 			signingTime = time.Now()
 		}	
 	}

--- a/requestctx/requestctx.go
+++ b/requestctx/requestctx.go
@@ -1,0 +1,59 @@
+package requestctx
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+
+type RequestCtx struct{
+	//A request ID which is used to correlate log entries to a request. Each request gets a random ID
+	//which will be most likely a globally unique ID. The Requester could however chose a Request ID
+	//in case they want to do multiple requests with a single ID (e.g. for troubleshooting).
+	RequestID string
+	// -> Request info (See S3 access log for inspiration)
+}
+
+type key int
+var requestCtxKey key
+
+func getRandomRequestId() string {
+	return uuid.New().String()
+}
+
+const XRequestID string = "X-Request-ID"
+
+func getRequestIdFromHttpRequest(req *http.Request) string {
+	reqId := req.Header.Get(XRequestID)
+	if reqId == "" {
+		return getRandomRequestId()
+	} else {
+		return reqId
+	}
+}
+
+func NewContextFromHttpRequest(req *http.Request) context.Context{
+	rCtx := RequestCtx{
+		RequestID: getRequestIdFromHttpRequest(req),
+	}
+	return NewContext(req.Context(), &rCtx)
+}
+
+func NewContext(ctx context.Context, rCtx *RequestCtx) context.Context{
+	return context.WithValue(ctx, requestCtxKey, rCtx)
+}
+
+func FromContext(ctx context.Context) (*RequestCtx, bool) {
+	rCtx, ok := ctx.Value(requestCtxKey).(*RequestCtx)
+	return rCtx, ok
+}
+
+func GetRequestID(ctx context.Context) string {
+	rCtx, ok := FromContext(ctx)
+	if ok {
+		return rCtx.RequestID
+	}
+	return ""
+}


### PR DESCRIPTION
Allow to run golang benchmarks using something like:
```
go test -bench=. -benchtime=5s -run "FakeS3Proxy" -benchmem -count=6 | tee bench_logs.txt
```
Allow context aware logging avoiding the need to pass request ID on every log call.
Allow enabling debug logging at request scope.