### PR TITLE
Feature/head for presigned urls

### DIFF
--- a/aws/service/s3/mwauthorizes3.go
+++ b/aws/service/s3/mwauthorizes3.go
@@ -54,7 +54,7 @@ func authorizeS3Action(ctx context.Context, sessionToken, targetRegion string, a
 	maxExpiryTime time.Time, jwtVerifier utils.JWTVerifier, policyRetriever iaminterfaces.PolicyRetriever, vhi interfaces.VirtualHosterIdentifier) (allowed bool) {
 	allowed = false
 	var jwtKeyFunc jwt.Keyfunc = jwtVerifier.GetJwtKeyFunc()
-	if action == api.GetObject {
+	if action == api.GetObject || action == api.HeadObject {
 		//Grace time is active and authentication has already checked token validity
 		jwtKeyFunc = nil
 	}

--- a/cmd/almost-e2e_test.go
+++ b/cmd/almost-e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -411,6 +412,91 @@ func TestSigv4PresignedUrlsWork(t *testing.T) {
 		}
 		if string(bytes) != backendRegion {
 			t.Errorf("Invalid response of presigned url expected %s, got %s", backendRegion, string(bytes))
+		}
+	}
+}
+
+
+func TestHmacV1PresignedUrlsHeadObjectWorks(t *testing.T) {
+	//Given a running proxy and credentials against that proxy that allow access for the get operation
+	tearDown, getSignedToken, stsServer, s3Server := testingFixture(t)
+	defer tearDown()
+	token := getSignedToken("mySubject", time.Second * 2, session.AWSSessionTags{PrincipalTags: map[string][]string{"org": {"a"}}})
+	var durationSecs int32 = 2
+	creds := getCredentialsFromTestStsProxy(t, token, "my-session", testPolicyAllowAllARN, stsServer, &durationSecs)
+
+	//Given a Get request for the region.txt file
+	regionFileUrl := fmt.Sprintf("%s%s/%s", testutils.GetTestServerUrl(s3Server), testingBucketNameBackenddetails, testingRegionTxtObjectKey)
+	req, err := http.NewRequest(http.MethodHead, regionFileUrl, nil)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	//When creating a presigned url it and using that presigned url it should return the region correctly.
+	signedUri, err := presign.CalculateS3PresignedHmacV1QueryUrl(req, creds, 300)
+	if err != nil {
+		t.Errorf("Did not expect error when signing url. Got %s", err)
+	}
+	resp, err := testutils.BuildUnsafeHttpClientThatTrustsAnyCert(t).Head(signedUri)
+	if err != nil {
+		t.Errorf("Did not expect error when using signing url. Got %s", err)
+	}
+	bytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Did not expect error when getting body of signed url response. Got %s", err)
+	}
+	if string(bytes) != "" {
+		t.Errorf("invalid response of presigned url expected empty body, got %s", string(bytes))
+	}
+	contentLength, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 0, 32)
+	if err != nil {
+		t.Errorf("invalid Content-length %s cannot conver to int: %s", resp.Header.Get("Content-Length"), err)
+	}
+	if int(contentLength) != len(defaultBakendIdAlmostE2ETests) {
+		t.Errorf("invalid Content-length header expected %d, got %s", len(defaultBakendIdAlmostE2ETests), resp.Header.Get("Content-Length"))
+	}
+}
+
+func TestSigv4PresignedUrlsHeadObjectWorks(t *testing.T) {
+	//Given a running proxy and credentials against that proxy that allow access for the get operation
+	tearDown, getSignedToken, stsServer, s3Server := testingFixture(t)
+	defer tearDown()
+	token := getSignedToken("mySubject", time.Second * 2, session.AWSSessionTags{PrincipalTags: map[string][]string{"org": {"a"}}})
+	var durationSecs int32 = 2
+	creds := getCredentialsFromTestStsProxy(t, token, "my-session", testPolicyAllowAllARN, stsServer, &durationSecs)
+
+	//Given a Get request for the region.txt file
+	regionFileUrl := fmt.Sprintf("%s%s/%s", testutils.GetTestServerUrl(s3Server), testingBucketNameBackenddetails, testingRegionTxtObjectKey)
+	req, err := http.NewRequest(http.MethodHead, regionFileUrl, nil)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	}
+
+	//When creating a presigned url it and using that presigned url it should return the region correctly.
+	for _, backendRegion := range backendTestRegions {
+		signedUri, _, err := presign.PreSignRequestWithCreds(context.Background(), req, 300, time.Now(), creds, backendRegion)
+		if err != nil {
+			t.Errorf("Did not expect error when signing url for %s. Got %s", backendRegion, err)
+		}
+		resp, err := testutils.BuildUnsafeHttpClientThatTrustsAnyCert(t).Head(signedUri)
+		if err != nil {
+			t.Errorf("Did not expect error when using signing url for %s. Got %s", backendRegion, err)
+		}
+		bytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("Did not expect error when getting body of signed url response for %s. Got %s", backendRegion, err)
+		}
+		if string(bytes) != "" {
+			t.Errorf("invalid response of presigned url expected empty body, got %s", string(bytes))
+		}
+		contentLength, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 0, 32)
+		if err != nil {
+			t.Errorf("invalid Content-length %s cannot conver to int: %s", resp.Header.Get("Content-Length"), err)
+		}
+		if int(contentLength) != len(backendRegion) {
+			t.Errorf("invalid Content-length header expected %d, got %s", len(backendRegion), resp.Header.Get("Content-Length"))
 		}
 	}
 }

--- a/presign/hmacv1query.go
+++ b/presign/hmacv1query.go
@@ -175,8 +175,8 @@ func getExpiresFromExpirySeconds(expirySeconds int) string {
 
 func getCanonicalRequestString(req *http.Request, expires string) (string, error) {
 	method := strings.ToUpper(req.Method)
-	if method != http.MethodGet {
-		return "", errors.New("only Get is implemented at the moment")
+	if method != http.MethodGet && method != http.MethodHead {
+		return "", errors.New("only Get and Head are implemented at the moment")
 	}
 	cs := method + "\n"
 	canonicalStandardHeaders := getCanonicalStandardHeaders(req, expires)


### PR DESCRIPTION
Currently HeadObject with a HmacV1 query url will fail.

This relaxes checks and allows such use cases.