### PR TITLE
feature: AllowHeadAsGet

### DIFF
--- a/constants/proxy-constants.go
+++ b/constants/proxy-constants.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	// Relax the checking of sigV4 signature that when a head is performed the signature
+	// still gets checked as it where a HEAD. GetObject and HeadObject both require the same
+	// IAM permissions so why not allow both type of HTTP requests. Note This must be passed
+	// as a query parameter BEFORE signing because it is expected to be signed.
+	HeadAsGet = "X-Proxy-Head-As-Get"
+)


### PR DESCRIPTION
When during signing the Query parameter "X-Proxy-Head-As-Get" is passed with a value of "true" then the URL can also be checked for Head requests (basically a HeadObject call) The "X-Proxy-Head-As-Get" parameter is always stripped of the request and never reaches the upstream.