### PR TITLE
feature: allow removable query parameters for presigned URLs

### DIFF
--- a/aws/service/s3/policy-api-action_test.go
+++ b/aws/service/s3/policy-api-action_test.go
@@ -42,7 +42,7 @@ func newStubJustReturnApiAction(ti *testing.T) interfaces.HandlerBuilderI {
 }
 
 func TestExpectedAPIActionIdentified(t *testing.T) {
-	teardownSuite, s := setupSuiteProxyS3(t, newStubJustReturnApiAction(t), nil, nil, []middleware.Middleware{RegisterOperation()},true)
+	teardownSuite, s := setupSuiteProxyS3(t, newStubJustReturnApiAction(t), nil, nil, []middleware.Middleware{RegisterOperation()}, true, nil)
 	defer teardownSuite(t)
 
 	for _, tc := range getApiAndIAMActionTestCases() { //see policy_iam_action_test

--- a/aws/service/s3/policy-iam-action_test.go
+++ b/aws/service/s3/policy-iam-action_test.go
@@ -369,7 +369,7 @@ func getApiAndIAMActionTestCases() ([]apiAndIAMActionTestCase) {
 //Removing/changing context values (e.g. if there are bugs) are breaking changes and should be
 //treated as such.
 func TestExpectedIamActionsAreReturned(t *testing.T) {
-	teardownSuite, s := setupSuiteProxyS3(t, newStubJustReturnIamAction(t), nil, nil, []middleware.Middleware{RegisterOperation()}, true)
+	teardownSuite, s := setupSuiteProxyS3(t, newStubJustReturnIamAction(t), nil, nil, []middleware.Middleware{RegisterOperation()}, true, nil)
 	defer teardownSuite(t)
 
 	for _, tc := range getApiAndIAMActionTestCases() {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ const(
 	s3ProxyKeyFile = "s3ProxyKeyFile"
 	s3ProxyJwtPublicRSAKey = "s3ProxyJwtPublicRSAKey"
 	s3ProxyJwtPrivateRSAKey = "s3ProxyJwtPrivateRSAKey"
+	s3ProxyRemovableQueryParams = "s3ProxyRemovableQueryParams"
 	stsProxyFQDN = "stsProxyFQDN"
 	stsProxyPort = "stsProxyPort"
 	stsProxyCertFile = "stsProxyCertFile"
@@ -64,6 +66,7 @@ const(
 	FAKES3PP_S3_PROXY_KEY_FILE = "FAKES3PP_S3_PROXY_KEY_FILE"
 	FAKES3PP_S3_PROXY_JWT_PUBLIC_RSA_KEY = "FAKES3PP_S3_PROXY_JWT_PUBLIC_RSA_KEY"
 	FAKES3PP_S3_PROXY_JWT_PRIVATE_RSA_KEY = "FAKES3PP_S3_PROXY_JWT_PRIVATE_RSA_KEY"
+	FAKES3PP_S3_PROXY_REMOVABLE_QUERY_PARAMS = "FAKES3PP_S3_PROXY_REMOVABLE_QUERY_PARAMS"
 	FAKES3PP_STS_PROXY_FQDN = "FAKES3PP_STS_PROXY_FQDN"
 	FAKES3PP_STS_PROXY_PORT = "FAKES3PP_STS_PROXY_PORT"
 	FAKES3PP_STS_PROXY_CERT_FILE = "FAKES3PP_STS_PROXY_CERT_FILE"
@@ -124,6 +127,13 @@ var envVarDefs = []envVarDef{
 		true,
 		"The key file used for signing JWT tokens",
 		[]string{proxys3, proxysts},
+	},
+	{
+		s3ProxyRemovableQueryParams,
+		FAKES3PP_S3_PROXY_REMOVABLE_QUERY_PARAMS,
+		false,
+		"A comma separated list of regexes for query parameter keys that should be ignored",
+		[]string{proxys3},
 	},
 	{
 		stsProxyFQDN,
@@ -264,6 +274,26 @@ func getS3ProxyFQDNs() ([]string, error) {
 		return nil, err
 	}
 	return fqdns, nil
+}
+
+//Retrieve the regular expressions that are passed in for removal of query parameter keys that
+//should be removed. Makes sure they compile and fail fast if there is an invalid regex.
+func getS3RemovableQueryParamRegexes() ([]*regexp.Regexp, error) {
+	var queryParamNames []string
+	var queryParamNameRegexes []*regexp.Regexp = make([]*regexp.Regexp, 0)
+	err := viper.UnmarshalKey(s3ProxyRemovableQueryParams, &queryParamNames)
+	if err != nil {
+		return nil, err
+	}
+	for _, queryParamName := range queryParamNames {
+		candidate, err := regexp.Compile(queryParamName)
+		if err != nil {
+			err = fmt.Errorf("got %w when processing removable query param %s", err, queryParamName)
+			return nil, err
+		}
+		queryParamNameRegexes = append(queryParamNameRegexes, candidate)
+	}
+	return queryParamNameRegexes, nil
 }
 
 //TODO: make sure same is used for STS

--- a/cmd/proxys3.go
+++ b/cmd/proxys3.go
@@ -27,6 +27,12 @@ func buildS3Server() (server.Serverable) {
 		panic(fmt.Sprintf("Could not get sts proxy fqdns: %s", err))
 	}
 
+	removableQueryParams, err := getS3RemovableQueryParamRegexes()
+	if err != nil {
+		slog.Error("Could not get removable query param regexes", "error", err)
+		panic(fmt.Sprintf("Could not get removable query param regexess: %s", err))
+	}
+
 	s, err := s3.NewS3Server(
 		viper.GetString(s3ProxyJwtPrivateRSAKey),
 		viper.GetInt(s3ProxyPort),
@@ -38,6 +44,7 @@ func buildS3Server() (server.Serverable) {
 		nil,
 		viper.GetString(s3BackendConfigFile),
 		viper.GetBool(enableLegacyBehaviorInvalidRegionToDefaultRegion),
+		removableQueryParams,
 	)
 	if err != nil {
 		slog.Error("Could not create S3 server", "error", err)

--- a/middleware/authentication_options.go
+++ b/middleware/authentication_options.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -10,6 +11,10 @@ import (
 type AuthenticationOptions struct {
 	//How long signatures can be expired before denying them
 	Leeway time.Duration
+
+	//Which query parameters should be removed for presigned urls
+	//They will be removed prior to checking authentication
+	RemovableQueryParams []*regexp.Regexp
 }
 
 func (a *AuthenticationOptions) GetParserOptions() ([]jwt.ParserOption) {


### PR DESCRIPTION
Removable query parameters are parameters that are added by frameworks or instrumentation client side but which should not be taken into consideration for S3 operation.

Such parameters could prove problematic for presigned URLs because it won't be possible to validate the signature as the canonical string for signing is composed of all the query parameters so having query parameters added after signing will make the signature invalid. This feature allows to setup regexes to remove query parameters based on patterns that will be matched with the keys of query parameters. If they matched they will be removed before validation of the signature. They will remain ignored and will not be communicated in the request to the S3 backend.

If you need query parameters that should be passed to the backend then it is recommended to change the code that generates the presigned url to include those parameters. For e.g. in Python you can register on the events `before-sign.s3.GetObject` and `provide-client-params.s3.GetObjectprovide-client-params.s3.GetObject` (this is documented on SO: https://stackoverflow.com/questions/59056522/create-a-presigned-s3-url-for-get-object-with-custom-logging-information-using-b )

If you want removal then you should set FAKES3PP_S3_PROXY_REMOVABLE_QUERY_PARAMS to a comma separated string of regexes. So if you target a singe query parameter named `_please_ignore` then it is recommended to anchor the regex so use something like: `FAKES3PP_S3_PROXY_REMOVABLE_QUERY_PARAMS="^_please_ignore$"

Regexes allow flexibility but you should be careful with meta-characters. An easy way to test is to use a small golang app like https://gist.github.com/pvbouwel/02b42b899bbc1478b29fc75a24902cb5 if you do not have golang setup locally you can use the go playground https://go.dev/play/p/bq4oU4GU05a